### PR TITLE
Add Table Pluralization

### DIFF
--- a/EFBulkInsert/EFBulkInsert.csproj
+++ b/EFBulkInsert/EFBulkInsert.csproj
@@ -31,15 +31,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+    <Reference Include="EntityFramework">
+      <HintPath>packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer">
+      <HintPath>packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data.Entity.Design" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/EFBulkInsert/Extensions/DbContextExtensions.cs
+++ b/EFBulkInsert/Extensions/DbContextExtensions.cs
@@ -44,7 +44,7 @@ namespace EFBulkInsert.Extensions
             {
                 TempTableName = "##TEMP_" + Guid.NewGuid().ToString().Replace('-', '_'),
                 Type = typeof(T),
-                TableName = storageSpaceEntityType.Name,
+                TableName = System.Data.Entity.Design.PluralizationServices.PluralizationService.CreateService(System.Globalization.CultureInfo.GetCultureInfo("en-us")).Pluralize(storageSpaceEntityType.Name),
                 Properties = storageSpaceEntityType.Properties.Select(x => new EntityProperty
                 {
                     ColumnName = x.Name,


### PR DESCRIPTION
In many cases the standard naming convention is to have EF models be in the singular (e.g. Item) and generated tables (and collections) be in the plural (e.g. Items). This fork adds that functionality. It may make sense to make this a boolean configuration or parameter.